### PR TITLE
Use VertexOffset to render 64k + vertices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/inkyblackness/imgui-go-examples
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-gl/glfw v0.0.0-20210727001814-0db043d8d5be
-	github.com/inkyblackness/imgui-go/v4 v4.2.0
+	github.com/inkyblackness/imgui-go/v4 v4.2.1-0.20210724131045-a65ee31efab5
 	github.com/veandco/go-sdl2 v0.4.10
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-gl/glfw v0.0.0-20210727001814-0db043d8d5be h1:UVW91pfMB1GRQfVwC7//RGVbqX6Ea8jURmJhlANak1M=
 github.com/go-gl/glfw v0.0.0-20210727001814-0db043d8d5be/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
-github.com/inkyblackness/imgui-go/v4 v4.2.0 h1:5MuhU1tocnrHDZHyHTArzYr1X0+oA3ITleEwgx9juQ4=
-github.com/inkyblackness/imgui-go/v4 v4.2.0/go.mod h1:g8SAGtOYUP7rYaOB2AsVKCEHmPMDmJKgt4z6d+flhb0=
+github.com/inkyblackness/imgui-go/v4 v4.2.1-0.20210724131045-a65ee31efab5 h1:uRxk1zBgsGjge/s+GX2TNoW2PyxRpsJ0SMA4jIXOI9M=
+github.com/inkyblackness/imgui-go/v4 v4.2.1-0.20210724131045-a65ee31efab5/go.mod h1:g8SAGtOYUP7rYaOB2AsVKCEHmPMDmJKgt4z6d+flhb0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/renderers/OpenGL3.go
+++ b/internal/renderers/OpenGL3.go
@@ -45,6 +45,9 @@ func NewOpenGL3(io imgui.IO) (*OpenGL3, error) {
 		glslVersion: "#version 150",
 	}
 	renderer.createDeviceObjects()
+
+	io.SetBackendFlags(io.GetBackendFlags() | imgui.BackendFlagsRendererHasVtxOffset)
+
 	return renderer, nil
 }
 
@@ -158,7 +161,6 @@ func (renderer *OpenGL3) Render(displaySize [2]float32, framebufferSize [2]float
 
 	// Draw
 	for _, list := range drawData.CommandLists() {
-		var indexBufferOffset uintptr
 
 		vertexBuffer, vertexBufferSize := list.VertexBuffer()
 		gl.BindBuffer(gl.ARRAY_BUFFER, renderer.vboHandle)
@@ -175,9 +177,9 @@ func (renderer *OpenGL3) Render(displaySize [2]float32, framebufferSize [2]float
 				gl.BindTexture(gl.TEXTURE_2D, uint32(cmd.TextureID()))
 				clipRect := cmd.ClipRect()
 				gl.Scissor(int32(clipRect.X), int32(fbHeight)-int32(clipRect.W), int32(clipRect.Z-clipRect.X), int32(clipRect.W-clipRect.Y))
-				gl.DrawElementsWithOffset(gl.TRIANGLES, int32(cmd.ElementCount()), uint32(drawType), indexBufferOffset)
+				gl.DrawElementsBaseVertexWithOffset(gl.TRIANGLES, int32(cmd.ElementCount()), uint32(drawType), uintptr(cmd.IndexOffset()*indexSize), int32(cmd.VertexOffset()))
 			}
-			indexBufferOffset += uintptr(cmd.ElementCount() * indexSize)
+
 		}
 	}
 	gl.DeleteVertexArrays(1, &vaoHandle)


### PR DESCRIPTION
Depends on https://github.com/inkyblackness/imgui-go/pull/154

This allows the OpenGL3 backend to render 64k+ vertices 